### PR TITLE
EC-299: Extracted eContent demo data installer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor
 /composer.lock
+/.php_cs.cache

--- a/.php_cs
+++ b/.php_cs
@@ -1,0 +1,13 @@
+<?php
+
+return EzSystems\EzPlatformCodeStyle\PhpCsFixer\EzPlatformInternalConfigFactory::build()
+    ->setFinder(
+        PhpCsFixer\Finder::create()
+            ->in(
+                [
+                    __DIR__ . '/src',
+                ]
+            )
+            ->files()->name('*.php')
+    )
+;

--- a/README.md
+++ b/README.md
@@ -4,8 +4,22 @@ This package contains eContent sample data installer for testing purposes.
 
 ## Installation
 
+1. Install the package
+    ```
+    composer require ezsystems/ezcommerce-econtent-installer
+    ```
+
+1. Enable the bundle in your `config/bundles.php`:
+    ```php
+    Ibexa\Platform\Bundle\Commerce\EContentInstaller\IbexaPlatformCommerceEContentInstallerBundle::class => ['all' => true],    
+    ```
+   
+## Usage
+
+To install eContent demo data use the following Symfony command:
+
 ```
-composer require ezsystems/ezcommerce-econtent-installer
+php bin/console ezplatform:install commerce-econtent-demo
 ``` 
 
 ## COPYRIGHT

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     },
     "require": {
         "php": "^7.3",
+        "ezsystems/ezcommerce-demo-assets": "~1.0.0",
         "ezsystems/ezplatform-kernel": "~1.2.0",
         "symfony/http-kernel": "^5.1"
     },

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,9 @@
     "require": {
         "php": "^7.3"
     },
+    "config": {
+        "sort-packages": true
+    },
     "extra": {
         "branch-alias": {
             "dev-main": "1.0.x-dev"

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,14 @@
     "require": {
         "php": "^7.3"
     },
+    "require-dev": {
+        "ezsystems/ezplatform-code-style": "^0.2.0"
+    },
     "config": {
         "sort-packages": true
+    },
+    "scripts": {
+        "fix-cs": "@php ./vendor/bin/php-cs-fixer fix -v --show-progress=estimating"
     },
     "extra": {
         "branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
         }
     ],
     "require": {
+        "php": "^7.3"
     },
     "extra": {
         "branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Ibexa Commerce eContent data installer",
     "minimum-stability": "stable",
     "license": "proprietary",
-    "type": "ibexa-bundle",
+    "type": "symfony-bundle",
     "authors": [
         {
             "name": "Ibexa dev-team",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         }
     },
     "require": {
-        "php": "^7.3"
+        "php": "^7.3",
+        "symfony/http-kernel": "^5.1"
     },
     "require-dev": {
         "ezsystems/ezplatform-code-style": "^0.2.0"

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     },
     "require": {
         "php": "^7.3",
+        "ezsystems/ezplatform-kernel": "~1.2.0",
         "symfony/http-kernel": "^5.1"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,11 @@
             "homepage": "https://github.com/ezsystems/ezcommerce/contributors"
         }
     ],
+    "autoload": {
+        "psr-4": {
+            "Ibexa\\Platform\\Bundle\\Commerce\\EContentInstaller\\": "src/bundle"
+        }
+    },
     "require": {
         "php": "^7.3"
     },

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
     ],
     "autoload": {
         "psr-4": {
-            "Ibexa\\Platform\\Bundle\\Commerce\\EContentInstaller\\": "src/bundle"
+            "Ibexa\\Platform\\Bundle\\Commerce\\EContentInstaller\\": "src/bundle",
+            "Ibexa\\Platform\\Commerce\\EContentInstaller\\": "src/lib"
         }
     },
     "require": {

--- a/src/bundle/DependencyInjection/IbexaPlatformCommerceEContentInstallerExtension.php
+++ b/src/bundle/DependencyInjection/IbexaPlatformCommerceEContentInstallerExtension.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Platform\Bundle\Commerce\EContentInstaller\DependencyInjection;
+
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+
+/**
+ * @internal
+ */
+final class IbexaPlatformCommerceEContentInstallerExtension extends Extension
+{
+    /**
+     * @throws \Exception
+     */
+    public function load(array $configs, ContainerBuilder $container): void
+    {
+        $loader = new YamlFileLoader(
+            $container,
+            new FileLocator(__DIR__ . '/../Resources/config')
+        );
+        $loader->load('services.yaml');
+    }
+}

--- a/src/bundle/IbexaPlatformCommerceEContentInstallerBundle.php
+++ b/src/bundle/IbexaPlatformCommerceEContentInstallerBundle.php
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Platform\Bundle\Commerce\EContentInstaller;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class IbexaPlatformCommerceEContentInstallerBundle extends Bundle
+{
+}

--- a/src/bundle/Resources/config/services.yaml
+++ b/src/bundle/Resources/config/services.yaml
@@ -1,0 +1,20 @@
+parameters:
+    ibexa.commerce.installer.econtent.demo_assets_path: '%kernel.project_dir%/vendor/ezsystems/ezcommerce-demo-assets/assets/product_images'
+    ibexa.commerce.installer.econtent.binary_files_path: '%webroot_dir%/var/assets/product_images'
+
+services:
+    _defaults:
+        autowire: true
+        autoconfigure: true
+        public: false
+
+    Ibexa\Platform\Commerce\EContentInstaller\Installer\EContentDemoInstaller:
+        parent: EzSystems\PlatformInstallerBundle\Installer\DbBasedInstaller
+        arguments:
+            $db: '@ezpublish.persistence.connection'
+            $configResolver: '@ezpublish.config.resolver'
+            $demoDataDumpFilePath: '@=service("kernel").locateResource("@IbexaPlatformCommerceEContentInstallerBundle/Resources/migrations/demo/econtent_demo.sql")'
+            $binaryFilesSrcPath: '%ibexa.commerce.installer.econtent.demo_assets_path%'
+            $binaryFilesDstPath: '%ibexa.commerce.installer.econtent.binary_files_path%'
+        tags:
+            - { name: ezplatform.installer, type: commerce-econtent-demo }

--- a/src/lib/Installer/EContentDemoInstaller.php
+++ b/src/lib/Installer/EContentDemoInstaller.php
@@ -1,0 +1,119 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Platform\Commerce\EContentInstaller\Installer;
+
+use Doctrine\DBAL\Connection;
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
+use EzSystems\PlatformInstallerBundle\Installer\DbBasedInstaller;
+use EzSystems\PlatformInstallerBundle\Installer\Installer;
+use Symfony\Component\Console\Exception\InvalidArgumentException;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Process\Process;
+use function sprintf;
+
+/**
+ * @internal
+ */
+class EContentDemoInstaller extends DbBasedInstaller implements Installer
+{
+    private const INDEX_ECONTENT_COMMAND = 'php -d max_execution_time=-1 bin/console silversolutions:indexecontent --live-core';
+    private const ECONTENT_DATA_PROVIDER = 'econtent';
+
+    protected $migrationPath;
+
+    protected $projectRootDir;
+
+    /** @var \eZ\Publish\Core\MVC\ConfigResolverInterface */
+    protected $configResolver;
+
+    /** @var string */
+    private $demoDataDumpFilePath;
+
+    /** @var string */
+    private $binaryFilesDstPath;
+
+    /** @var string */
+    private $binaryFilesSrcPath;
+
+    public function __construct(
+        Connection $db,
+        ConfigResolverInterface $configResolver,
+        string $demoDataDumpFilePath,
+        string $binaryFilesSrcPath,
+        string $binaryFilesDstPath
+    ) {
+        parent::__construct($db);
+
+        $this->configResolver = $configResolver;
+        $this->demoDataDumpFilePath = $demoDataDumpFilePath;
+        $this->binaryFilesDstPath = $binaryFilesDstPath;
+        $this->binaryFilesSrcPath = $binaryFilesSrcPath;
+    }
+
+    public function importData(): void
+    {
+        $this->validateDataProviderConfiguration();
+        // import demo data
+        $this->runQueriesFromFile($this->demoDataDumpFilePath);
+
+        $this->output->writeln('Indexing eContent...');
+        $process = Process::fromShellCommandline(self::INDEX_ECONTENT_COMMAND);
+        $process->setTimeout(3600);
+        $process->setIdleTimeout(600);
+
+        $process->run(
+            function (string $type, string $output): void {
+                $this->output->write($output, false, OutputInterface::OUTPUT_RAW);
+            }
+        );
+    }
+
+    private function validateDataProviderConfiguration(): void
+    {
+        $dataProvider = $this->configResolver->getParameter(
+            'catalog_data_provider',
+            'silver_eshop'
+        );
+        if (self::ECONTENT_DATA_PROVIDER !== $dataProvider) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Expected "%s" data provider, but "%s" is set. eContent demo data won\'t be ' .
+                    'imported. Switch the data provider first.',
+                    self::ECONTENT_DATA_PROVIDER,
+                    $dataProvider
+                )
+            );
+        }
+    }
+
+    public function importSchema(): void
+    {
+        // No schema to be imported
+    }
+
+    public function createConfiguration(): void
+    {
+        // Unused
+    }
+
+    public function importBinaries(): void
+    {
+        $this->output->writeln(
+            sprintf(
+                "Copying assets from\n  <comment>%s</comment>\nto\n  <comment>%s</comment>",
+                $this->binaryFilesSrcPath,
+                $this->binaryFilesDstPath
+            )
+        );
+        $fs = new Filesystem();
+        $fs->mirror($this->binaryFilesSrcPath, $this->binaryFilesDstPath);
+        $this->output->writeln('<info>Assets copied</info>');
+    }
+}


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [EC-299](https://issues.ibexa.co/browse/EC-299)
| **Type**                                   | improvement
| **Target eZ Platform version** | `v3.2`+
| **Related to** | Related to ezsystems/ezcommerce-shop#196, ezsystems/ezcommerce#41
| **BC breaks**                          | no
| **Doc needed**                       | no, internal

Since ezsystems/ezcommerce#37 we no longer have had eContent demo data dump in the product, this PR adds installer and that data dump to this separate package. Internal instruction on how to use it has been updated already.

This is mostly a copy, with refactoring, of the installer dropped via ezsystems/ezcommerce-shop#196. As an improvement automatic demo assets mirroring was added, since installers already support it.